### PR TITLE
Update wiki_structure.py - update reference id max size to 300

### DIFF
--- a/symmetry-unified-backend/app/models/wiki_structure.py
+++ b/symmetry-unified-backend/app/models/wiki_structure.py
@@ -11,7 +11,7 @@ class Citation(BaseModel):
 class Reference(BaseModel):
     model_config = {"frozen": True}
     label: str = Field(max_length=10000)
-    id: Optional[str] = Field(default=None, max_length=100)
+    id: Optional[str] = Field(default=None, max_length=300)
     url: Optional[str] = Field(default=None, max_length=2000)
 
 


### PR DESCRIPTION
Fix bug that can cause internal server error while running backend.

I got this error when calling structured article on: https://en.wikipedia.org/wiki/Despre_tine